### PR TITLE
Add aspects

### DIFF
--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -27,7 +27,7 @@
 		expansions: [],
 		players: 1,
 		difficulty: 0,
-		spiritNames: createSpiritsModel(),
+		spiritOrAspectNames: createSpiritsModel(),
 		mapNames: createMapsModel(),
 		boardNames: createBoardsModel(),
 		scenarioNames: createScenariosModel(),

--- a/src/components/features/Config.svelte
+++ b/src/components/features/Config.svelte
@@ -28,7 +28,7 @@
 	import type { MapName } from "@models/game/maps";
 	import type { Players } from "@models/game/players";
 	import type { ScenarioName } from "@models/game/scenarios";
-	import type { SpiritName } from "@models/game/spirits";
+	import type { AspectName, SpiritName } from "@models/game/spirits";
 	import {
 		createAdversariesModel,
 		createBoardsModel,
@@ -41,7 +41,7 @@
 	export let expansions: ExpansionName[];
 	export let players: Players;
 	export let difficulty: Difficulty;
-	export let spiritNames: SpiritName[];
+	export let spiritOrAspectNames: (SpiritName | AspectName)[];
 	export let mapNames: MapName[];
 	export let boardNames: BalancedBoardName[]
 	export let scenarioNames: ScenarioName[];
@@ -56,12 +56,12 @@
 	let config: IConfig;
 	let validCombos: ICombo[];
 	$: { config = {
-		expansions, players, difficulty, mapNames, boardNames, spiritNames, scenarioNames, adversaryNamesAndIds
+		expansions, players, difficulty, mapNames, boardNames, spiritOrAspectNames, scenarioNames, adversaryNamesAndIds
 	}};
 	$: { validCombos = getValidCombos(config) };
 	$: jaggedEarthSelected = expansions.includes("Jagged Earth");
 	$: playersError = !jaggedEarthSelected && players > 4;
-	$: spiritsError = players > spiritNames.length;
+	$: spiritsError = players > spiritOrAspectNames.filter(n => SPIRITS.find(s => s.name == n) !== undefined).length;
 	$: mapsError = !mapNames.length;
 	$: boardsError = players > boardNames.length;
 	$: scenariosError = !scenarioNames.length;
@@ -80,7 +80,7 @@
 	}
 
 	function updateModels(expansions: ExpansionName[]): void {
-		spiritNames = createUpdatedModel(createSpiritsModel, spiritNames, expansions);
+		spiritOrAspectNames = createUpdatedModel(createSpiritsModel, spiritOrAspectNames, expansions);
 		mapNames = createUpdatedModel(createMapsModel, mapNames, expansions);
 		boardNames = createUpdatedModel(createBoardsModel, boardNames, expansions);
 		scenarioNames = createUpdatedModel(createScenariosModel, scenarioNames, expansions);
@@ -135,11 +135,12 @@
 			>
 				<CheckboxesGroup title="Spirits"
 					items={getOptionsByExpansion(SPIRITS, expansions)}
-					getId={(spirit) => spirit.name}
-					bind:model={spiritNames}
-					let:item={spirit}
+					getId={(spiritOrAspect) => spiritOrAspect.name}
+					getChildren={(entity) => getOptionsByExpansion(entity.aspects, expansions)}
+					bind:model={spiritOrAspectNames}
+					let:item={spiritOrAspect}
 				>
-					{spirit.name} <ExpansionEmblem value={spirit.expansion} />
+					{spiritOrAspect.name} <ExpansionEmblem value={spiritOrAspect.expansion} />
 				</CheckboxesGroup>
 			</Card>
 

--- a/src/components/features/GameSetup.svelte
+++ b/src/components/features/GameSetup.svelte
@@ -89,6 +89,10 @@
 							<Separator />
 							{spirit.name}
 							<ExpansionEmblem value={spirit.expansion} />
+							{#if spirit.aspects}
+								({spirit.aspects[0].name}
+								<ExpansionEmblem value={spirit.aspects[0].expansion} />)
+							{/if}
 						</li>
 					{/each}
 				</ul>

--- a/src/data/spirits.ts
+++ b/src/data/spirits.ts
@@ -9,13 +9,34 @@ export const SPIRITS: ISpirit[] = [
 	{ name: "Grinning Trickster Stirs Up Trouble", expansion: "Jagged Earth" },
 	{ name: "Heart of the Wildfire", expansion: "Promo Pack 1" },
 	{ name: "Keeper of the Forbidden Wilds", expansion: "Branch & Claw" },
-	{ name: "Lightning's Swift Strike" },
+	{ 
+		name: "Lightning's Swift Strike",
+		aspects: [
+			{ name: "Immense", expansion: "Promo Pack 2" },
+			{ name: "Pandemonium", expansion: "Jagged Earth" },
+			{ name: "Wind", expansion: "Jagged Earth" },
+		]
+	},
 	{ name: "Lure of the Deep Wilderness", expansion: "Jagged Earth" },
 	{ name: "Many Minds Move as One", expansion: "Jagged Earth" },
 	{ name: "Ocean's Hungry Grasp" },
-	{ name: "River Surges in Sunlight" },
+	{ 
+		name: "River Surges in Sunlight",
+		aspects: [
+			{ name: "Sunshine", expansion: "Jagged Earth" },
+			{ name: "Travel", expansion: "Promo Pack 2" },
+		] 
+	},
 	{ name: "Serpent Slumbering Beneath the Island", expansion: "Promo Pack 1" },
-	{ name: "Shadows Flicker Like Flame" },
+	{ 
+		name: "Shadows Flicker Like Flame",
+		aspects: [
+			{ name: "Amorphous", expansion: "Promo Pack 2" },
+			{ name: "Foreboding", expansion: "Promo Pack 2" },
+			{ name: "Madness", expansion: "Jagged Earth" },
+			{ name: "Reach", expansion: "Jagged Earth" },
+		]
+	},
 	{ name: "Sharp Fangs Behind the Leaves", expansion: "Branch & Claw" },
 	{ name: "Shifting Memory of Ages", expansion: "Jagged Earth" },
 	{ name: "Shroud of Silent Mist", expansion: "Jagged Earth" },
@@ -23,6 +44,12 @@ export const SPIRITS: ISpirit[] = [
 	{ name: "Stone's Unyielding Defiance", expansion: "Jagged Earth" },
 	{ name: "Thunderspeaker" },
 	{ name: "Vengeance as a Burning Plague", expansion: "Jagged Earth" },
-	{ name: "Vital Strength of the Earth" },
+	{ 
+		name: "Vital Strength of the Earth",
+		aspects: [
+			{ name: "Might", expansion: "Promo Pack 2" },
+			{ name: "Resilience", expansion: "Jagged Earth" },
+		]
+ 	},
 	{ name: "Volcano Looming High", expansion: "Jagged Earth" },
 ];

--- a/src/debugging/mock-data.ts
+++ b/src/debugging/mock-data.ts
@@ -1,5 +1,6 @@
 import type { IConfig } from "@models/config.interface";
 import type { AdversaryName, AdversaryLevelId } from "@models/game/adversaries";
+import type { SpiritName, AspectName } from "@models/game/spirits";
 import { ADVERSARIES } from "@data/adversaries";
 import { BOARDS } from "@data/boards";
 import { EXPANSIONS } from "@data/expansions";
@@ -13,7 +14,11 @@ export const MOCK_CONFIG: IConfig = {
 	expansions: EXPANSIONS,
 	players: 4,
 	difficulty: 8,
-	spiritNames: SPIRITS.map(spirit => spirit.name),
+	spiritOrAspectNames: SPIRITS.reduce((model, spirit) => {
+		model.push(spirit.name);
+		spirit.aspects?.forEach(aspect => model.push(aspect.name));
+		return model;		
+	}, [] as (SpiritName | AspectName)[]),
 	mapNames: MAPS.map(map => map.name),
 	boardNames: BOARDS.map(board => board.name),
 	scenarioNames: SCENARIOS.map(scenario => scenario.name),

--- a/src/functions/create-game-setup.ts
+++ b/src/functions/create-game-setup.ts
@@ -4,12 +4,12 @@ import type { IConfig } from "@models/config.interface";
 import type { IGameSetup } from "@models/game-setup.interface";
 import { selectRandom } from "./utility/select-random";
 import { selectBoards } from "./select-boards";
-import { getOptionsByName } from "./get-options";
+import { selectSpirits, getSpirits } from "./select-spirits";
 
 export function createGameSetup(config: IConfig, validCombos: ICombo[]): IGameSetup {
 	const [selectedMap, selectedAdversaryLevel, selectedScenario] = selectRandom(validCombos)[0];
-	const randomSpiritNames = selectRandom(config.spiritNames, config.players);
-	const selectedSpirits = getOptionsByName(SPIRITS, randomSpiritNames);
+	const randomSpirits = selectSpirits(config.spiritOrAspectNames, config.players);
+	const selectedSpirits = getSpirits(randomSpirits);
 	const selectedBoards = selectBoards(selectedMap.name, config.players, config.boardNames);
 
 	return {

--- a/src/functions/create-model.ts
+++ b/src/functions/create-model.ts
@@ -8,11 +8,17 @@ import type { BalancedBoardName } from "@models/game/board";
 import type { ExpansionName, IExpansionOption } from "@models/game/expansions";
 import type { MapName } from "@models/game/maps";
 import type { ScenarioName } from "@models/game/scenarios";
-import type { SpiritName } from "@models/game/spirits";
+import type { SpiritName, AspectName } from "@models/game/spirits";
 import { getOptionsByExpansion } from "./get-options";
 
-export function createSpiritsModel(expansions: ExpansionName[] = []): SpiritName[] {
-	return createModel(SPIRITS, expansions);
+export function createSpiritsModel(expansions: ExpansionName[] = []): (SpiritName | AspectName)[] {
+	return getOptionsByExpansion(SPIRITS, expansions).reduce((spiritsOrAspects, spirit) => {
+		spiritsOrAspects.push(spirit.name);
+		spirit.aspects?.forEach(aspect => {
+			spiritsOrAspects.push(aspect.name);
+		});
+		return spiritsOrAspects;
+	}, [] as (SpiritName | AspectName)[])
 }
 
 export function createMapsModel(expansions: ExpansionName[] = []): MapName[] {

--- a/src/functions/get-options.ts
+++ b/src/functions/get-options.ts
@@ -37,11 +37,15 @@ export function getOptionsByExpansion<TOption extends IExpansionOption>(
 	options: TOption[],
 	expansions: ExpansionName[]
 ): TOption[] {
-	return options.filter(item => {
-		if (item.expansion) {
-			return expansions.includes(item.expansion);
-		} else {
-			return true;
-		}
-	});
+	if(options){
+		return options.filter(item => {
+			if (item.expansion) {
+				return expansions.includes(item.expansion);
+			} else {
+				return true;
+			}
+		});
+	} else {
+		return [];
+	}
 }

--- a/src/functions/select-spirits.ts
+++ b/src/functions/select-spirits.ts
@@ -1,0 +1,61 @@
+import { SPIRITS } from "@data/spirits";
+import type { ISpirit, IAspect, SpiritName, AspectName } from "@models/game/spirits";
+import { selectRandom } from "./utility/select-random";
+
+export function selectSpirits(
+    possibleNames: (SpiritName | AspectName)[],
+    quantity: number
+) : (SpiritName | AspectName)[] {
+    // Get distinct spirit names
+    const possibleSpiritNames = possibleNames.filter(n => SPIRITS.find(s => s.name == n) !== undefined);
+    // Select 1 random spirit for each player
+    const spiritNames = selectRandom(possibleSpiritNames, quantity);
+
+    return spiritNames.map(spiritName => {
+        // The spirit with no aspect is always a possibility
+        var possibleNamesForSpirit = [ spiritName ];
+        // Get all aspects for this spirit.
+        var spiritAspects = SPIRITS.find(s => s.name == spiritName)?.aspects?.map(a => a.name);
+        // Now get the avaialble aspects for this spirit based on the filtered list selected by the user.
+        var possibleAspects = spiritAspects?.filter(a => possibleNames.filter(n => n === a).length > 0);
+        possibleAspects?.forEach(a => possibleNamesForSpirit.push(a));
+        // Now select at random from the spirit name or one of it's available aspects.
+        return selectRandom(possibleNamesForSpirit)[0]
+    });
+}
+
+
+export function getSpirits(
+	names: (SpiritName | AspectName)[],
+): ISpirit[] {
+    
+	const filteredSpirits: ISpirit[] = [];
+	for (let name of names) {
+		let foundSpirit = SPIRITS.find(spirit => spirit.name === name);
+        let foundAspect: IAspect | undefined;
+        if(foundSpirit === undefined) {            
+            foundSpirit = SPIRITS.find(spirit => spirit.aspects?.filter(a => a.name === name).length ?? 0 > 0);
+            foundAspect = foundSpirit?.aspects?.find(aspect => aspect.name === name);
+        }
+
+        if (foundSpirit) {
+            if(foundSpirit.aspects) {
+                // Spirit has aspects so we need to create a new spirit 
+                // entry without any aspects to return and then add
+                // the single selected aspect if needed.
+                let spiritResult: ISpirit = {
+                    name: foundSpirit.name,
+                    expansion: foundSpirit.expansion,
+                }
+                if (foundAspect) {
+                    spiritResult.aspects = [ foundAspect ]
+                }
+                filteredSpirits.push(spiritResult);
+            } else {        
+                // No aspects so just add the original spirit data.
+                filteredSpirits.push(foundSpirit);
+            }
+        }
+	}
+	return filteredSpirits;
+}

--- a/src/functions/select-spirits.ts
+++ b/src/functions/select-spirits.ts
@@ -7,7 +7,9 @@ export function selectSpirits(
     quantity: number
 ) : (SpiritName | AspectName)[] {
     // Get distinct spirit names
-    const possibleSpiritNames = possibleNames.filter(n => SPIRITS.find(s => s.name == n) !== undefined);
+    const possibleSpiritNames = possibleNames.filter(n => 
+        SPIRITS.find(s => s.name == n) !== undefined || 
+        SPIRITS.find(s => s.aspects?.find(a => a.name == n)) !== undefined);
     // Select 1 random spirit for each player
     const spiritNames = selectRandom(possibleSpiritNames, quantity);
 

--- a/src/models/config.interface.ts
+++ b/src/models/config.interface.ts
@@ -3,7 +3,7 @@ import type { Difficulty } from "./game/difficulty";
 import type { MapName } from "./game/maps";
 import type { BalancedBoardName } from "./game/board";
 import type { ExpansionName } from "./game/expansions";
-import type { SpiritName } from "./game/spirits";
+import type { SpiritName, AspectName } from "./game/spirits";
 import type { AdversaryName, AdversaryLevelId } from "./game/adversaries";
 import type { ScenarioName } from "./game/scenarios";
 
@@ -15,7 +15,7 @@ export interface IConfig {
 	expansions: ExpansionName[];
 	players: Players;
 	difficulty: Difficulty;
-	spiritNames: SpiritName[];
+	spiritOrAspectNames: (SpiritName | AspectName)[];
 	mapNames: MapName[];
 	boardNames: BalancedBoardName[];
 	scenarioNames: ScenarioName[];

--- a/src/models/game/spirits.ts
+++ b/src/models/game/spirits.ts
@@ -27,5 +27,24 @@ export type SpiritName =
 	"Volcano Looming High";
 
 export interface ISpirit extends IExpansionOption {
-	name: SpiritName;
+	name: SpiritName,
+	aspects?: IAspect[];
+}
+
+export type AspectName =
+	"None" |
+	"Immense" |
+	"Pandemonium" |
+	"Wind" |
+	"Sunshine" |
+	"Travel" |
+	"Amorphous" |
+	"Foreboding" |
+	"Madness" |
+	"Reach" |
+	"Might" |
+	"Resilience";
+
+export interface IAspect extends IExpansionOption {
+	name: AspectName;
 }


### PR DESCRIPTION
User can now select aspects to include when game configruation is generated.

I'm not convinced this is the best way to do it, but it does work for the most part.

**Outstanding issues:**
* If just one aspect is selected, the validation thinks that the spirit is not selected, so shows an error.
* Display of spirits and aspects is a little messy with empty lines.
* It's not currently possible to specify that you want the option of playing a base spirit unless you also have all it's aspects selected.
* The spirits are all selected by default but the aspects are not.
* The display of some spirit/aspect combos is a little messy on the game setup page. (e.g. Foreboding Shadows and Resilience Earth)