### PR TITLE
Fix scenario name to 'Despicable Theft'

### DIFF
--- a/src/data/scenarios.ts
+++ b/src/data/scenarios.ts
@@ -39,7 +39,7 @@ export const SCENARIOS: IScenario[] = [
 		expansion: "Promo Pack 2",
 	},
 	{
-		name: "Despicable Thief",
+		name: "Despicable Theft",
 		difficulty: 2,
 		expansion: "Jagged Earth",
 	},


### PR DESCRIPTION
Hi! I didn't see any contributing docs so hope it's okay that I opened this PR; I use this tool all the time and really appreciate it! I noticed when using it that the name of this scenario was slightly off and changed the constant to fix it.

# Changes
* Changes scenario name from `Despicable Thief` to `Despicable Theft` 
  * source from wiki (and my own copy haha): https://spiritislandwiki.com/index.php?title=Despicable_Theft

# Screenshot
## before
![image](https://user-images.githubusercontent.com/6327663/142715897-0a85f490-1e58-4880-91d0-50532fe2fb3c.png)
## after
![image](https://user-images.githubusercontent.com/6327663/142715901-26ba1c25-3030-4dc3-a97f-bd88b58ab88e.png)
