### PR TITLE
Simplifies type names

### DIFF
--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -12,13 +12,13 @@
 		createSpiritsModel,
 	} from "@functions/create-model";
 	import { createGameSetup } from "@functions/create-game-setup";
-	import { EPage } from "@models/page.enum";
-	import type { ICombo } from "@models/combo.interface";
-	import type { IConfig } from "@models/config.interface";
-	import type { IGameSetup } from "@models/game-setup.interface";
+	import { Page } from "@models/page.enum";
+	import type { Combo } from "@models/combo.interface";
+	import type { Config } from "@models/config.interface";
+	import type { GameSetup } from "@models/game-setup.interface";
 
-	let page: EPage = EPage.Config;
-	let config: IConfig = {
+	let page: Page = Page.Config;
+	let config: Config = {
 		expansions: [],
 		players: 1,
 		difficultyRange: [0, 1],
@@ -28,8 +28,8 @@
 		scenarioNames: createScenariosModel(),
 		adversaryNamesAndIds: createAdversariesModel(),
 	};
-	let validCombos: ICombo[] | undefined;
-	let gameSetup: IGameSetup | undefined;
+	let validCombos: Combo[] | undefined;
+	let gameSetup: GameSetup | undefined;
 
 	const OLD_KEY = "SPIRIT_ISLANDER_CONFIG";
 	const NEW_KEY = "SPIRIT_ISLANDER_CONFIG_NEW";
@@ -51,26 +51,26 @@
 		}
 	});
 
-	function setConfigInLocalStorage(config: IConfig): void {
+	function setConfigInLocalStorage(config: Config): void {
 		const configJSON = JSON.stringify(config);
 		localStorage.setItem(NEW_KEY, configJSON);
 	}
 </script>
 
 <Header />
-{#if page === EPage.Config}
+{#if page === Page.Config}
 	<Config {...config}
 		on:generate={(e) => {
-			page = EPage.GameSetup;
+			page = Page.GameSetup;
 			config = e.detail.config;
 			validCombos = e.detail.validCombos;
 			gameSetup = createGameSetup(config, validCombos);
 			setConfigInLocalStorage(config);
 		}}
 	/>
-{:else if page === EPage.GameSetup && gameSetup && validCombos}
+{:else if page === Page.GameSetup && gameSetup && validCombos}
 	<GameSetup {...gameSetup}
-		on:reset={() => page = EPage.Config}
+		on:reset={() => page = Page.Config}
 		on:generate={() => {
 			if (validCombos) {
 				gameSetup = createGameSetup(config, validCombos);

--- a/src/components/features/Config.svelte
+++ b/src/components/features/Config.svelte
@@ -24,8 +24,8 @@
 	import type { BalancedBoardName } from "@models/game/board";
 	import type { Difficulty } from "@models/game/difficulty";
 	import type { ExpansionName } from "@models/game/expansions";
-	import type { ICombo } from "@models/combo.interface";
-	import type { IConfig } from "@models/config.interface";
+	import type { Combo } from "@models/combo.interface";
+	import type { Config } from "@models/config.interface";
 	import type { MapName } from "@models/game/maps";
 	import type { Players } from "@models/game/players";
 	import type { ScenarioName } from "@models/game/scenarios";
@@ -49,13 +49,13 @@
 	export let adversaryNamesAndIds: (AdversaryName | AdversaryLevelId)[];
 	const dispatcher = createEventDispatcher<{
 		generate: {
-			config: IConfig,
-			validCombos: ICombo[],
+			config: Config,
+			validCombos: Combo[],
 		}
 	}>();
 
-	let config: IConfig;
-	let validCombos: ICombo[];
+	let config: Config;
+	let validCombos: Combo[];
 	$: { config = {
 		expansions, players, difficultyRange, mapNames, boardNames, spiritNames, scenarioNames, adversaryNamesAndIds
 	}};

--- a/src/components/features/GameSetup.svelte
+++ b/src/components/features/GameSetup.svelte
@@ -14,11 +14,11 @@
 	import type { ExpansionName } from "@models/game/expansions";
 	import type { Players } from "@models/game/players";
 	import type { Difficulty } from "@models/game/difficulty";
-	import type { IAdversaryLevel } from "@models/game/adversaries";
-	import type { IBoard } from "@models/game/board";
-	import type { IMap } from "@models/game/maps";
-	import type { IScenario } from "@models/game/scenarios";
-	import type { ISpirit } from "@models/game/spirits";
+	import type { AdversaryLevel } from "@models/game/adversaries";
+	import type { Board } from "@models/game/board";
+	import type { Map } from "@models/game/maps";
+	import type { Scenario } from "@models/game/scenarios";
+	import type { Spirit } from "@models/game/spirits";
 
 	const dispatcher = createEventDispatcher<{
 		reset: void;
@@ -27,11 +27,11 @@
 	export let expansions: ExpansionName[];
 	export let players: Players;
 	export let difficulty: Difficulty;
-	export let spirits: ISpirit[];
-	export let map: IMap;
-	export let boards: IBoard[];
-	export let adversaryLevel: IAdversaryLevel;
-	export let scenario: IScenario;
+	export let spirits: Spirit[];
+	export let map: Map;
+	export let boards: Board[];
+	export let adversaryLevel: AdversaryLevel;
+	export let scenario: Scenario;
 
 	$: adversaryName = getAdversaryById(adversaryLevel.id);
 </script>

--- a/src/components/shared/BoardEmblem.svelte
+++ b/src/components/shared/BoardEmblem.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import Emblem from "./Emblem.svelte";
-	import type { BalancedBoardName, IBoard, ThematicBoardName } from "@models/game/board";
+	import type { BalancedBoardName, Board, ThematicBoardName } from "@models/game/board";
 	import type { MapName } from "@models/game/maps";
 	import { snakeCase } from "@functions/utility/snake-case";
 
-	export let board: IBoard;
+	export let board: Board;
 	export let mapName: MapName;
 	let boardName: BalancedBoardName | string;
 

--- a/src/data/adversaries.ts
+++ b/src/data/adversaries.ts
@@ -1,6 +1,6 @@
-import type { IAdversary } from "@models/game/adversaries";
+import type { Adversary } from "@models/game/adversaries";
 
-export const ADVERSARIES: IAdversary[] = [
+export const ADVERSARIES: Adversary[] = [
 	{
 		name: "No Adversary",
 		levels: [],

--- a/src/data/boards.ts
+++ b/src/data/boards.ts
@@ -1,6 +1,6 @@
-import type { IBoard } from "@models/game/board";
+import type { Board } from "@models/game/board";
 
-export const BOARDS: IBoard[] = [
+export const BOARDS: Board[] = [
 	{
 		name: "A",
 		thematicName: "Northeast",

--- a/src/data/maps.ts
+++ b/src/data/maps.ts
@@ -1,6 +1,6 @@
-import type { IMap } from "@models/game/maps";
+import type { Map } from "@models/game/maps";
 
-export const MAPS: IMap[] = [
+export const MAPS: Map[] = [
 	{
 		name: "Balanced",
 		difficulty: 0,

--- a/src/data/scenarios.ts
+++ b/src/data/scenarios.ts
@@ -1,6 +1,6 @@
-import type { IScenario } from "@models/game/scenarios";
+import type { Scenario } from "@models/game/scenarios";
 
-export const SCENARIOS: IScenario[] = [
+export const SCENARIOS: Scenario[] = [
 	{
 		name: "No Scenario",
 		difficulty: 0,

--- a/src/data/spirits.ts
+++ b/src/data/spirits.ts
@@ -1,6 +1,6 @@
-import type { ISpirit } from "@models/game/spirits";
+import type { Spirit } from "@models/game/spirits";
 
-export const SPIRITS: ISpirit[] = [
+export const SPIRITS: Spirit[] = [
 	{ name: "A Spread of Rampant Green" },
 	{ name: "Bringer of Dreams and Nightmares" },
 	{ name: "Downpour Drenches the World", expansion: "Promo Pack 2" },

--- a/src/functions/create-game-setup.spec.ts
+++ b/src/functions/create-game-setup.spec.ts
@@ -4,14 +4,14 @@ import { EXPANSIONS } from "@data/expansions";
 import { MAPS } from "@data/maps";
 import { SCENARIOS } from "@data/scenarios";
 import { SPIRITS } from "@data/spirits";
-import type { IConfig } from "@models/config.interface";
+import type { Config } from "@models/config.interface";
 import type { AdversaryName, AdversaryLevelId } from "@models/game/adversaries";
 import { createGameSetup } from "./create-game-setup";
 import { getValidCombos } from "./get-valid-combos";
 
 describe("createGameSetup", () => {
 	it("returns a randomly-generated game setup", () => {
-		const mockConfig: IConfig = {
+		const mockConfig: Config = {
 			expansions: EXPANSIONS,
 			players: 4,
 			difficultyRange: [5, 8],

--- a/src/functions/create-game-setup.ts
+++ b/src/functions/create-game-setup.ts
@@ -1,14 +1,14 @@
 import { SPIRITS } from "@data/spirits";
-import type { ICombo } from "@models/combo.interface";
-import type { IConfig } from "@models/config.interface";
-import type { IGameSetup } from "@models/game-setup.interface";
+import type { Combo } from "@models/combo.interface";
+import type { Config } from "@models/config.interface";
+import type { GameSetup } from "@models/game-setup.interface";
 import { selectRandom } from "./utility/select-random";
 import { selectBoards } from "./select-boards";
 import { getOptionsByName } from "./get-options";
 import { getDifficulty } from "./get-difficulty";
 import type { Difficulty } from "@models/game/difficulty";
 
-export function createGameSetup(config: IConfig, validCombos: ICombo[]): IGameSetup {
+export function createGameSetup(config: Config, validCombos: Combo[]): GameSetup {
 	const {players, expansions, spiritNames, boardNames} = config;
 
 	// Randomly choose a combination of a map, adversary, and scenario and determine the total difficulty

--- a/src/functions/create-model.ts
+++ b/src/functions/create-model.ts
@@ -5,7 +5,7 @@ import { SCENARIOS } from "@data/scenarios";
 import { SPIRITS } from "@data/spirits";
 import type { AdversaryLevelId, AdversaryName } from "@models/game/adversaries";
 import type { BalancedBoardName } from "@models/game/board";
-import type { ExpansionName, IExpansionOption } from "@models/game/expansions";
+import type { ExpansionName, ExpansionOption } from "@models/game/expansions";
 import type { MapName } from "@models/game/maps";
 import type { ScenarioName } from "@models/game/scenarios";
 import type { SpiritName } from "@models/game/spirits";
@@ -37,7 +37,7 @@ export function createAdversariesModel(expansions: ExpansionName[] = []): (Adver
 	}, [] as (AdversaryName | AdversaryLevelId)[])
 }
 
-interface IGenericExpansionOption<TName extends string> extends IExpansionOption {
+interface IGenericExpansionOption<TName extends string> extends ExpansionOption {
 	name: TName;
 }
 

--- a/src/functions/create-model.ts
+++ b/src/functions/create-model.ts
@@ -37,12 +37,12 @@ export function createAdversariesModel(expansions: ExpansionName[] = []): (Adver
 	}, [] as (AdversaryName | AdversaryLevelId)[])
 }
 
-interface IGenericExpansionOption<TName extends string> extends ExpansionOption {
+interface GenericExpansionOption<TName extends string> extends ExpansionOption {
 	name: TName;
 }
 
 function createModel<TName extends string>(
-	options: IGenericExpansionOption<TName>[],
+	options: GenericExpansionOption<TName>[],
 	expansions: ExpansionName[]
 ): TName[] {
 	return getOptionsByExpansion(options, expansions).map(option => option.name);

--- a/src/functions/get-difficulty.spec.ts
+++ b/src/functions/get-difficulty.spec.ts
@@ -1,9 +1,9 @@
-import type { IDifficultyOption } from "@models/game/difficulty";
+import type { DifficultyOption } from "@models/game/difficulty";
 import { getDifficulty } from "./get-difficulty";
 
 describe("getDifficulty", () => {
 	it("returns static difficulty value", () => {
-		const mockItem: IDifficultyOption = {
+		const mockItem: DifficultyOption = {
 			name: "Fake Item",
 			difficulty: 4,
 		};
@@ -23,7 +23,7 @@ describe("getDifficulty", () => {
 	});
 
 	it("returns dynamic difficulty value", () => {
-		const mockItem: IDifficultyOption = {
+		const mockItem: DifficultyOption = {
 			name: "Fake Item",
 			difficulty: expansions => {
 				if (expansions.length >= 2) {

--- a/src/functions/get-options.spec.ts
+++ b/src/functions/get-options.spec.ts
@@ -1,10 +1,10 @@
 import { getOptionsByExpansion, getOptionsByName } from "./get-options";
-import type { BalancedBoardName, IBoard } from "../models/game/board";
-import type { ISpirit, SpiritName } from "../models/game/spirits";
+import type { BalancedBoardName, Board } from "../models/game/board";
+import type { Spirit, SpiritName } from "../models/game/spirits";
 
 describe("getOptions", () => {
-	let mockSpirits: ISpirit[];
-	let mockBoards: IBoard[];
+	let mockSpirits: Spirit[];
+	let mockBoards: Board[];
 
 	beforeEach(() => {
 		mockSpirits = [
@@ -28,7 +28,7 @@ describe("getOptions", () => {
 				{ name: "Keeper of the Forbidden Wilds", expansion: "Branch & Claw" },
 			]);
 
-			expect(getOptionsByName<ISpirit, SpiritName>(mockSpirits, ["Fractured Days Split the Sky", "Downpour Drenches the World"])).toStrictEqual([
+			expect(getOptionsByName<Spirit, SpiritName>(mockSpirits, ["Fractured Days Split the Sky", "Downpour Drenches the World"])).toStrictEqual([
 				{ name: "Fractured Days Split the Sky", expansion: "Jagged Earth" },
 				{ name: "Downpour Drenches the World", expansion: "Promo Pack 2" },
 			]);
@@ -40,7 +40,7 @@ describe("getOptions", () => {
 				{ name: "D", thematicName: "West" },
 			]);
  
-			expect(getOptionsByName<IBoard, BalancedBoardName>(mockBoards, ["E"])).toStrictEqual([
+			expect(getOptionsByName<Board, BalancedBoardName>(mockBoards, ["E"])).toStrictEqual([
 				{ name: "E", thematicName: "Southeast", expansion: "Jagged Earth" },
 			]);
 		});

--- a/src/functions/get-options.ts
+++ b/src/functions/get-options.ts
@@ -1,5 +1,5 @@
-import type { ExpansionName, IExpansionOption } from "@models/game/expansions";
-import type { IOption } from "@models/game/option";
+import type { ExpansionName, ExpansionOption } from "@models/game/expansions";
+import type { Option } from "@models/game/option";
 
 /**
  * Get options that have specified names
@@ -10,7 +10,7 @@ import type { IOption } from "@models/game/option";
  * @returns 
  * Array of options that have specified names
  */
-export function getOptionsByName<TOption extends IOption, TName extends string>(
+export function getOptionsByName<TOption extends Option, TName extends string>(
 	options: TOption[],
 	names: TName[]
 ): TOption[] {
@@ -35,7 +35,7 @@ export function getOptionsByName<TOption extends IOption, TName extends string>(
  * @returns 
  * Array of options from base game and specified expansions
  */
-export function getOptionsByExpansion<TOption extends IExpansionOption>(
+export function getOptionsByExpansion<TOption extends ExpansionOption>(
 	options: TOption[],
 	expansions: ExpansionName[]
 ): TOption[] {

--- a/src/functions/get-valid-combos.spec.ts
+++ b/src/functions/get-valid-combos.spec.ts
@@ -1,5 +1,5 @@
 import { getValidCombos } from "./get-valid-combos";
-import type { IConfig } from "@models/config.interface";
+import type { Config } from "@models/config.interface";
 import type { AdversaryName, AdversaryLevelId } from "@models/game/adversaries";
 import { ADVERSARIES } from "@data/adversaries";
 import { BOARDS } from "@data/boards";
@@ -10,7 +10,7 @@ import { SPIRITS } from "@data/spirits";
 
 describe("getValidCombos", () => {
 	it("returns possible combinations for lowest difficulty", () => {
-		const mockConfig: IConfig = {
+		const mockConfig: Config = {
 			expansions: EXPANSIONS,
 			players: 1,
 			difficultyRange: [0, 0],
@@ -60,7 +60,7 @@ describe("getValidCombos", () => {
 	});
 
 	it("returns all possible combinations", () => {
-		const mockConfig: IConfig = {
+		const mockConfig: Config = {
 			expansions: EXPANSIONS,
 			players: 1,
 			difficultyRange: [0, 11],

--- a/src/functions/get-valid-combos.ts
+++ b/src/functions/get-valid-combos.ts
@@ -1,21 +1,21 @@
-import type { IDifficultyOption } from "@models/game/difficulty";
-import type { IConfig } from "@models/config.interface";
-import type { IAdversaryLevel } from "@models/game/adversaries";
-import type { IMap } from "@models/game/maps";
-import type { IScenario } from "@models/game/scenarios";
+import type { DifficultyOption } from "@models/game/difficulty";
+import type { Config } from "@models/config.interface";
+import type { AdversaryLevel } from "@models/game/adversaries";
+import type { Map } from "@models/game/maps";
+import type { Scenario } from "@models/game/scenarios";
 import { ADVERSARIES } from "@data/adversaries";
 import { MAPS } from "@data/maps";
 import { SCENARIOS } from "@data/scenarios";
 import { getDifficulty } from "./get-difficulty";
 import { ComboAnalyzer } from "./utility/combo-analyzer";
 
-const comboAnalyzer = new ComboAnalyzer<IDifficultyOption>();
+const comboAnalyzer = new ComboAnalyzer<DifficultyOption>();
 
-export function getValidCombos(config: IConfig): [IMap, IAdversaryLevel, IScenario][] {
+export function getValidCombos(config: Config): [Map, AdversaryLevel, Scenario][] {
 	const { mapNames, scenarioNames, adversaryNamesAndIds } = config;
 	const maps = MAPS.filter(map => mapNames.includes(map.name));
 	const scenarios = SCENARIOS.filter(scenario => scenarioNames.includes(scenario.name));
-	const adversaries: IAdversaryLevel[] = [];
+	const adversaries: AdversaryLevel[] = [];
 
 	if (adversaryNamesAndIds.includes("No Adversary")) {
 		adversaries.push({ id: "none", name: "N/A", difficulty: 0 });

--- a/src/functions/select-boards.ts
+++ b/src/functions/select-boards.ts
@@ -1,5 +1,5 @@
 import { BOARDS } from "@data/boards";
-import type { BalancedBoardName, IBoard } from "@models/game/board";
+import type { BalancedBoardName, Board } from "@models/game/board";
 import type { MapName } from "@models/game/maps";
 import type { Players } from "@models/game/players";
 import { getOptionsByName } from "./get-options";
@@ -9,7 +9,7 @@ export function selectBoards(
 	mapName: MapName,
 	players: Players,
 	boardNames: BalancedBoardName[]
-): IBoard[] {
+): Board[] {
 	if (mapName === "Balanced") {
 		const randomBoardNames = selectRandom(boardNames, players);
 		return getBoardsByName(randomBoardNames);
@@ -36,6 +36,6 @@ export function selectBoards(
 	}
 }
 
-function getBoardsByName(boardNames: BalancedBoardName[]): IBoard[] {
+function getBoardsByName(boardNames: BalancedBoardName[]): Board[] {
 	return getOptionsByName(BOARDS, boardNames);
 }

--- a/src/functions/utility/combo-analyzer.ts
+++ b/src/functions/utility/combo-analyzer.ts
@@ -3,346 +3,126 @@
  * @param getPossibleCombos Recursively loops through arrays of options to produce all valid combinations
  * @returns An array of every possible valid combination (a combination is an array comprised of one value taken from each array of options)
  */
-export class ComboAnalyzer<TOption> {
+export class ComboAnalyzer<T> {
 	public getPossibleCombos<
-		TOption1 extends TOption,
-		TOption2 extends TOption,
-		TOption3 extends TOption,
-		TOption4 extends TOption,
-		TOption5 extends TOption,
-		TOption6 extends TOption,
-		TOption7 extends TOption,
-		TOption8 extends TOption,
-		TOption9 extends TOption,
-		TOption10 extends TOption,
-		>(
-			allOptions: [
-				TOption1[],
-				TOption2[],
-				TOption3[],
-				TOption4[],
-				TOption5[],
-				TOption6[],
-				TOption7[],
-				TOption8[],
-				TOption9[],
-				TOption10[],
-			],
-			isValidCombo?: (
-				options: [
-					TOption1,
-					TOption2,
-					TOption3,
-					TOption4,
-					TOption5,
-					TOption6,
-					TOption7,
-					TOption8,
-					TOption9,
-					TOption10,
-				],
-			) => boolean,
-	): [
-		TOption1,
-		TOption2,
-		TOption3,
-		TOption4,
-		TOption5,
-		TOption6,
-		TOption7,
-		TOption8,
-		TOption9,
-		TOption10,
-	][];
+		T1 extends T,
+		T2 extends T,
+		T3 extends T,
+		T4 extends T,
+		T5 extends T,
+		T6 extends T,
+		T7 extends T,
+		T8 extends T,
+		T9 extends T,
+		T10 extends T,
+	>(
+		allOptions: [T1[], T2[], T3[], T4[], T5[], T6[], T7[], T8[], T9[], T10[]],
+		isValidCombo?: (options: [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]) => boolean,
+	): [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10][];
 	public getPossibleCombos<
-		TOption1 extends TOption,
-		TOption2 extends TOption,
-		TOption3 extends TOption,
-		TOption4 extends TOption,
-		TOption5 extends TOption,
-		TOption6 extends TOption,
-		TOption7 extends TOption,
-		TOption8 extends TOption,
-		TOption9 extends TOption,
-		>(
-			allOptions: [
-				TOption1[],
-				TOption2[],
-				TOption3[],
-				TOption4[],
-				TOption5[],
-				TOption6[],
-				TOption7[],
-				TOption8[],
-				TOption9[],
-			],
-			isValidCombo?: (
-				options: [
-					TOption1,
-					TOption2,
-					TOption3,
-					TOption4,
-					TOption5,
-					TOption6,
-					TOption7,
-					TOption8,
-					TOption9,
-				],
-			) => boolean,
-	): [
-		TOption1,
-		TOption2,
-		TOption3,
-		TOption4,
-		TOption5,
-		TOption6,
-		TOption7,
-		TOption8,
-		TOption9,
-	][];
+		T1 extends T,
+		T2 extends T,
+		T3 extends T,
+		T4 extends T,
+		T5 extends T,
+		T6 extends T,
+		T7 extends T,
+		T8 extends T,
+		T9 extends T,
+	>(
+		allOptions: [T1[], T2[], T3[], T4[], T5[], T6[], T7[], T8[], T9[]],
+		isValidCombo?: (options: [T1, T2, T3, T4, T5, T6, T7, T8, T9]) => boolean,
+	): [T1, T2, T3, T4, T5, T6, T7, T8, T9][];
 	public getPossibleCombos<
-		TOption1 extends TOption,
-		TOption2 extends TOption,
-		TOption3 extends TOption,
-		TOption4 extends TOption,
-		TOption5 extends TOption,
-		TOption6 extends TOption,
-		TOption7 extends TOption,
-		TOption8 extends TOption,
-		>(
-			allOptions: [
-				TOption1[],
-				TOption2[],
-				TOption3[],
-				TOption4[],
-				TOption5[],
-				TOption6[],
-				TOption7[],
-				TOption8[],
-			],
-			isValidCombo?: (
-				options: [
-					TOption1,
-					TOption2,
-					TOption3,
-					TOption4,
-					TOption5,
-					TOption6,
-					TOption7,
-					TOption8,
-				],
-			) => boolean,
-	): [
-		TOption1,
-		TOption2,
-		TOption3,
-		TOption4,
-		TOption5,
-		TOption6,
-		TOption7,
-		TOption8,
-	][];
+		T1 extends T,
+		T2 extends T,
+		T3 extends T,
+		T4 extends T,
+		T5 extends T,
+		T6 extends T,
+		T7 extends T,
+		T8 extends T,
+	>(
+		allOptions: [T1[], T2[], T3[], T4[], T5[], T6[], T7[], T8[]],
+		isValidCombo?: (options: [T1, T2, T3, T4, T5, T6, T7, T8]) => boolean,
+	): [T1, T2, T3, T4, T5, T6, T7, T8][];
 	public getPossibleCombos<
-		TOption1 extends TOption,
-		TOption2 extends TOption,
-		TOption3 extends TOption,
-		TOption4 extends TOption,
-		TOption5 extends TOption,
-		TOption6 extends TOption,
-		TOption7 extends TOption,
-		>(
-			allOptions: [
-				TOption1[],
-				TOption2[],
-				TOption3[],
-				TOption4[],
-				TOption5[],
-				TOption6[],
-				TOption7[],
-			],
-			isValidCombo?: (
-				options: [
-					TOption1,
-					TOption2,
-					TOption3,
-					TOption4,
-					TOption5,
-					TOption6,
-					TOption7,
-				],
-			) => boolean,
-	): [
-		TOption1,
-		TOption2,
-		TOption3,
-		TOption4,
-		TOption5,
-		TOption6,
-		TOption7,
-	][];
+		T1 extends T,
+		T2 extends T,
+		T3 extends T,
+		T4 extends T,
+		T5 extends T,
+		T6 extends T,
+		T7 extends T,
+	>(
+		allOptions: [T1[], T2[], T3[], T4[], T5[], T6[], T7[]],
+		isValidCombo?: (options: [T1, T2, T3, T4, T5, T6, T7]) => boolean,
+	): [T1, T2, T3, T4, T5, T6, T7][];
 	public getPossibleCombos<
-		TOption1 extends TOption,
-		TOption2 extends TOption,
-		TOption3 extends TOption,
-		TOption4 extends TOption,
-		TOption5 extends TOption,
-		TOption6 extends TOption,
-		>(
-			allOptions: [
-				TOption1[],
-				TOption2[],
-				TOption3[],
-				TOption4[],
-				TOption5[],
-				TOption6[],
-			],
-			isValidCombo?: (
-				options: [
-					TOption1,
-					TOption2,
-					TOption3,
-					TOption4,
-					TOption5,
-					TOption6,
-				],
-			) => boolean,
-	): [
-		TOption1,
-		TOption2,
-		TOption3,
-		TOption4,
-		TOption5,
-		TOption6,
-	][];
+		T1 extends T,
+		T2 extends T,
+		T3 extends T,
+		T4 extends T,
+		T5 extends T,
+		T6 extends T,
+	>(
+		allOptions: [T1[], T2[], T3[], T4[], T5[], T6[]],
+		isValidCombo?: (options: [T1, T2, T3, T4, T5, T6]) => boolean,
+	): [T1, T2, T3, T4, T5, T6][];
 	public getPossibleCombos<
-		TOption1 extends TOption,
-		TOption2 extends TOption,
-		TOption3 extends TOption,
-		TOption4 extends TOption,
-		TOption5 extends TOption,
-		>(
-			allOptions: [
-				TOption1[],
-				TOption2[],
-				TOption3[],
-				TOption4[],
-				TOption5[],
-			],
-			isValidCombo?: (
-				options: [
-					TOption1,
-					TOption2,
-					TOption3,
-					TOption4,
-					TOption5,
-				],
-			) => boolean,
-	): [
-		TOption1,
-		TOption2,
-		TOption3,
-		TOption4,
-		TOption5,
-	][];
+		T1 extends T,
+		T2 extends T,
+		T3 extends T,
+		T4 extends T,
+		T5 extends T,
+	>(
+		allOptions: [T1[], T2[], T3[], T4[], T5[]],
+		isValidCombo?: (options: [T1, T2, T3, T4, T5]) => boolean,
+	): [T1, T2, T3, T4, T5][];
 	public getPossibleCombos<
-		TOption1 extends TOption,
-		TOption2 extends TOption,
-		TOption3 extends TOption,
-		TOption4 extends TOption,
-		>(
-			allOptions: [
-				TOption1[],
-				TOption2[],
-				TOption3[],
-				TOption4[],
-			],
-			isValidCombo?: (
-				options: [
-					TOption1,
-					TOption2,
-					TOption3,
-					TOption4,
-				],
-			) => boolean,
-	): [
-		TOption1,
-		TOption2,
-		TOption3,
-		TOption4,
-	][];
+		T1 extends T,
+		T2 extends T,
+		T3 extends T,
+		T4 extends T,
+	>(
+		allOptions: [T1[], T2[], T3[], T4[]],
+		isValidCombo?: (options: [T1, T2, T3, T4]) => boolean,
+	): [T1, T2, T3, T4][];
 	public getPossibleCombos<
-		TOption1 extends TOption,
-		TOption2 extends TOption,
-		TOption3 extends TOption,
-		>(
-			allOptions: [
-				TOption1[],
-				TOption2[],
-				TOption3[],
-			],
-			isValidCombo?: (
-				options: [
-					TOption1,
-					TOption2,
-					TOption3,
-				],
-			) => boolean,
-	): [
-		TOption1,
-		TOption2,
-		TOption3,
-	][];
-	public getPossibleCombos<
-		TOption1 extends TOption,
-		TOption2 extends TOption,
-		>(
-			allOptions: [
-				TOption1[],
-				TOption2[],
-			],
-			isValidCombo?: (
-				options: [
-					TOption1,
-					TOption2,
-				],
-			) => boolean,
-	): [
-		TOption1,
-		TOption2,
-	][];
-	public getPossibleCombos<
-		TOption1 extends TOption,
-		>(
-			allOptions: [
-				TOption1[],
-			],
-			isValidCombo?: (
-				options: [
-					TOption1,
-				],
-			) => boolean,
-	): [
-		TOption1,
-	][];
+		T1 extends T,
+		T2 extends T,
+		T3 extends T,
+	>(
+		allOptions: [T1[],T2[],T3[]],
+		isValidCombo?: (options: [T1, T2, T3]) => boolean,
+	): [T1, T2, T3][];
+	public getPossibleCombos<T1 extends T, T2 extends T>(
+		allOptions: [T1[], T2[]],
+		isValidCombo?: (options: [T1, T2]) => boolean,
+	): [T1, T2][];
+	public getPossibleCombos<T1 extends T>(
+		allOptions: [T1[]],
+		isValidCombo?: (
+		options: [T1]) => boolean,
+	): [T1][];
 	public getPossibleCombos(
-		allOptions: TOption[][],
-		isValidCombo?: (options: TOption[]) => boolean,
-	): TOption[][];
+		allOptions: T[][],
+		isValidCombo?: (options: T[]) => boolean,
+	): T[][];
 	public getPossibleCombos(
-		allOptions: TOption[][],
+		allOptions: T[][],
 		isValidCombo?: unknown,
-	): TOption[][] {
-		// Return possible combos
-		return this._getPossibleCombos(allOptions, isValidCombo as (options: TOption[]) => boolean);
+	): T[][] {
+		return this._getPossibleCombos(allOptions, isValidCombo as (options: T[]) => boolean);
 	}
 
 	private _getPossibleCombos(
-		allOptionsLibrary: TOption[][],
-		isValidCombo: (options: TOption[]) => boolean = () => true,
-		possibleCombos: TOption[][] = [],
+		allOptionsLibrary: T[][],
+		isValidCombo: (options: T[]) => boolean = () => true,
+		possibleCombos: T[][] = [],
 		allOptionsIndex = 0,
-		currentCombo: TOption[] = [],
-	): TOption[][] {
+		currentCombo: T[] = [],
+	): T[][] {
 		// Check if combo is complete
 		if (allOptionsIndex === allOptionsLibrary.length) {
 			// Check if valid combo
@@ -351,13 +131,10 @@ export class ComboAnalyzer<TOption> {
 				possibleCombos.push([...currentCombo]);
 			}
 		} else {
-			// Get options
 			const options = allOptionsLibrary[allOptionsIndex];
-			// Run through options
+
 			options.forEach(option => {
-				// Set option in current combo
 				currentCombo[allOptionsIndex] = option;
-				// Add possible combos for next index
 				this._getPossibleCombos(
 					allOptionsLibrary,
 					isValidCombo,
@@ -367,7 +144,7 @@ export class ComboAnalyzer<TOption> {
 				);
 			});
 		}
-		// Return possible combos
+
 		return possibleCombos;
 	}
 }

--- a/src/models/combo.interface.ts
+++ b/src/models/combo.interface.ts
@@ -1,9 +1,9 @@
-import type { IMap } from "./game/maps";
-import type { IAdversaryLevel } from "./game/adversaries";
-import type { IScenario } from "./game/scenarios";
+import type { Map } from "./game/maps";
+import type { AdversaryLevel } from "./game/adversaries";
+import type { Scenario } from "./game/scenarios";
 
 /**
  * A valid combination of game setup options that 
  * together add up to a given level of `Difficulty`
  */
-export type ICombo = [IMap, IAdversaryLevel, IScenario];
+export type Combo = [Map, AdversaryLevel, Scenario];

--- a/src/models/config.interface.ts
+++ b/src/models/config.interface.ts
@@ -11,7 +11,7 @@ import type { ScenarioName } from "./game/scenarios";
  * Collection of selected options that a user either 
  * wants or would be willing to have in a `IGameSetup`
  */
-export interface IConfig {
+export interface Config {
 	expansions: ExpansionName[];
 	players: Players;
 	difficultyRange: Difficulty[];

--- a/src/models/game-setup.interface.ts
+++ b/src/models/game-setup.interface.ts
@@ -1,23 +1,23 @@
 import type { Players } from "./game/players";
 import type { Difficulty } from "./game/difficulty";
-import type { ISpirit } from "./game/spirits";
+import type { Spirit } from "./game/spirits";
 import type { ExpansionName } from "./game/expansions";
-import type { IAdversaryLevel } from "./game/adversaries";
-import type { IScenario } from "./game/scenarios";
-import type { IMap } from "./game/maps";
-import type { IBoard } from "./game/board";
+import type { AdversaryLevel } from "./game/adversaries";
+import type { Scenario } from "./game/scenarios";
+import type { Map } from "./game/maps";
+import type { Board } from "./game/board";
 
 /**
  * Collection of options chosen before play that
  * influence how to set up a game of Spirit Island
  */
-export interface IGameSetup {
+export interface GameSetup {
 	expansions: ExpansionName[];
 	players: Players;
 	difficulty: Difficulty;
-	spirits: ISpirit[];
-	map: IMap;
-	boards: IBoard[];
-	scenario: IScenario;
-	adversaryLevel: IAdversaryLevel;
+	spirits: Spirit[];
+	map: Map;
+	boards: Board[];
+	scenario: Scenario;
+	adversaryLevel: AdversaryLevel;
 }

--- a/src/models/game/adversaries.ts
+++ b/src/models/game/adversaries.ts
@@ -1,5 +1,5 @@
-import type { IDifficultyOption } from "./difficulty";
-import type { IExpansionOption } from "./expansions";
+import type { DifficultyOption } from "./difficulty";
+import type { ExpansionOption } from "./expansions";
 
 export type AdversaryName =
 	"No Adversary" |
@@ -21,7 +21,7 @@ export type AdversaryLevelName =
 	"Level 5" |
 	"Level 6";
 
-export interface IAdversaryLevel extends IDifficultyOption {
+export interface AdversaryLevel extends DifficultyOption {
 	id: AdversaryLevelId;
 	name: AdversaryLevelName;
 }
@@ -35,7 +35,7 @@ export type AdversaryLevelId = "none" |
 	"sc-0" | "sc-1" | "sc-2" | "sc-3" | "sc-4" | "sc-5" | "sc-6" |
 	"sw-0" | "sw-1" | "sw-2" | "sw-3" | "sw-4" | "sw-5" | "sw-6";
 
-export interface IAdversary extends IExpansionOption {
+export interface Adversary extends ExpansionOption {
 	name: AdversaryName,
-	levels: IAdversaryLevel[];
+	levels: AdversaryLevel[];
 }

--- a/src/models/game/board.ts
+++ b/src/models/game/board.ts
@@ -1,4 +1,4 @@
-import type { IExpansionOption } from "./expansions";
+import type { ExpansionOption } from "./expansions";
 
 export type BalancedBoardName =
 	"A" |
@@ -16,7 +16,7 @@ export type ThematicBoardName =
 	"Southeast" |
 	"Southwest";
 
-export interface IBoard extends IExpansionOption {
+export interface Board extends ExpansionOption {
 	name: BalancedBoardName;
 	thematicName: ThematicBoardName;
 }

--- a/src/models/game/difficulty.ts
+++ b/src/models/game/difficulty.ts
@@ -1,8 +1,8 @@
 import type { ExpansionName } from "./expansions";
-import type { IOption } from "./option";
+import type { Option } from "./option";
 
 export type Difficulty = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
-export interface IDifficultyOption extends IOption {
+export interface DifficultyOption extends Option {
 	difficulty: Difficulty | ((expansions: ExpansionName[]) => Difficulty);
 }

--- a/src/models/game/expansions.ts
+++ b/src/models/game/expansions.ts
@@ -1,4 +1,4 @@
-import type { IOption } from "./option";
+import type { Option } from "./option";
 
 export type ExpansionName =
 	"Branch & Claw" |
@@ -7,6 +7,6 @@ export type ExpansionName =
 	"Promo Pack 2"
 ;
 
-export interface IExpansionOption extends IOption {
+export interface ExpansionOption extends Option {
 	expansion?: ExpansionName;
 }

--- a/src/models/game/maps.ts
+++ b/src/models/game/maps.ts
@@ -1,8 +1,8 @@
-import type { IDifficultyOption } from "./difficulty";
-import type { IExpansionOption } from "./expansions";
+import type { DifficultyOption } from "./difficulty";
+import type { ExpansionOption } from "./expansions";
 
 export type MapName = "Balanced" | "Thematic";
 
-export interface IMap extends IDifficultyOption, IExpansionOption {
+export interface Map extends DifficultyOption, ExpansionOption {
 	name: MapName;
 }

--- a/src/models/game/option.ts
+++ b/src/models/game/option.ts
@@ -1,3 +1,3 @@
-export interface IOption {
+export interface Option {
 	name: string;
 }

--- a/src/models/game/scenarios.ts
+++ b/src/models/game/scenarios.ts
@@ -1,5 +1,5 @@
-import type { IDifficultyOption } from "./difficulty";
-import type { IExpansionOption } from "./expansions";
+import type { DifficultyOption } from "./difficulty";
+import type { ExpansionOption } from "./expansions";
 
 export type ScenarioName =
 	"No Scenario" |
@@ -17,6 +17,6 @@ export type ScenarioName =
 	"Varied Terrains" |
 	"Ward the Shores";
 
-export interface IScenario extends IDifficultyOption, IExpansionOption {
+export interface Scenario extends DifficultyOption, ExpansionOption {
 	name: ScenarioName;
 }

--- a/src/models/game/spirits.ts
+++ b/src/models/game/spirits.ts
@@ -1,4 +1,4 @@
-import type { IExpansionOption } from "./expansions";
+import type { ExpansionOption } from "./expansions";
 
 export type SpiritName =
 	"A Spread of Rampant Green" |
@@ -26,6 +26,6 @@ export type SpiritName =
 	"Vital Strength of the Earth" |
 	"Volcano Looming High";
 
-export interface ISpirit extends IExpansionOption {
+export interface Spirit extends ExpansionOption {
 	name: SpiritName;
 }

--- a/src/models/page.enum.ts
+++ b/src/models/page.enum.ts
@@ -1,4 +1,4 @@
-export enum EPage {
+export enum Page {
 	Config = 1,
 	GameSetup
 }


### PR DESCRIPTION
**Work done:**

1. Removes unnecessary letter prefix (aka the Hungarian notation style) from interfaces/enums
2. Flattens lines in combo-analyzer.ts to shorten the overall file