### PR TITLE
Generic arguments in types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,13 @@ module.exports = {
     }
   ],
   rules: {
-    quotes: ["error", "double"]
+    quotes: ["error", "double"],
+    "@typescript-eslint/no-empty-interface": [
+      "error",
+      {
+        "allowSingleExtends": true,
+      },
+    ],
   },
   settings: {
     "svelte3/typescript": true,

--- a/src/functions/create-game-setup.ts
+++ b/src/functions/create-game-setup.ts
@@ -9,7 +9,7 @@ import { getDifficulty } from "./get-difficulty";
 import type { Difficulty } from "@models/game/difficulty";
 
 export function createGameSetup(config: Config, validCombos: Combo[]): GameSetup {
-	const {players, expansions, spiritNames, boardNames} = config;
+	const { players, expansions, spiritNames, boardNames } = config;
 
 	// Randomly choose a combination of a map, adversary, and scenario and determine the total difficulty
 	const [selectedMap, selectedAdversaryLevel, selectedScenario] = selectRandom(validCombos)[0];

--- a/src/functions/create-model.ts
+++ b/src/functions/create-model.ts
@@ -37,12 +37,8 @@ export function createAdversariesModel(expansions: ExpansionName[] = []): (Adver
 	}, [] as (AdversaryName | AdversaryLevelId)[])
 }
 
-interface GenericExpansionOption<TName extends string> extends ExpansionOption {
-	name: TName;
-}
-
 function createModel<TName extends string>(
-	options: GenericExpansionOption<TName>[],
+	options: ExpansionOption<TName>[],
 	expansions: ExpansionName[]
 ): TName[] {
 	return getOptionsByExpansion(options, expansions).map(option => option.name);

--- a/src/functions/get-difficulty.spec.ts
+++ b/src/functions/get-difficulty.spec.ts
@@ -3,7 +3,7 @@ import { getDifficulty } from "./get-difficulty";
 
 describe("getDifficulty", () => {
 	it("returns static difficulty value", () => {
-		const mockItem: DifficultyOption = {
+		const mockItem: DifficultyOption<string> = {
 			name: "Fake Item",
 			difficulty: 4,
 		};
@@ -23,7 +23,7 @@ describe("getDifficulty", () => {
 	});
 
 	it("returns dynamic difficulty value", () => {
-		const mockItem: DifficultyOption = {
+		const mockItem: DifficultyOption<string> = {
 			name: "Fake Item",
 			difficulty: expansions => {
 				if (expansions.length >= 2) {

--- a/src/functions/get-options.spec.ts
+++ b/src/functions/get-options.spec.ts
@@ -28,7 +28,7 @@ describe("getOptions", () => {
 				{ name: "Keeper of the Forbidden Wilds", expansion: "Branch & Claw" },
 			]);
 
-			expect(getOptionsByName<Spirit, SpiritName>(mockSpirits, ["Fractured Days Split the Sky", "Downpour Drenches the World"])).toStrictEqual([
+			expect(getOptionsByName<SpiritName, Spirit>(mockSpirits, ["Fractured Days Split the Sky", "Downpour Drenches the World"])).toStrictEqual([
 				{ name: "Fractured Days Split the Sky", expansion: "Jagged Earth" },
 				{ name: "Downpour Drenches the World", expansion: "Promo Pack 2" },
 			]);
@@ -40,7 +40,7 @@ describe("getOptions", () => {
 				{ name: "D", thematicName: "West" },
 			]);
  
-			expect(getOptionsByName<Board, BalancedBoardName>(mockBoards, ["E"])).toStrictEqual([
+			expect(getOptionsByName<BalancedBoardName, Board>(mockBoards, ["E"])).toStrictEqual([
 				{ name: "E", thematicName: "Southeast", expansion: "Jagged Earth" },
 			]);
 		});

--- a/src/functions/get-options.ts
+++ b/src/functions/get-options.ts
@@ -10,7 +10,7 @@ import type { Option } from "@models/game/option";
  * @returns 
  * Array of options that have specified names
  */
-export function getOptionsByName<TOption extends Option, TName extends string>(
+export function getOptionsByName<TName extends string, TOption extends Option<TName>>(
 	options: TOption[],
 	names: TName[]
 ): TOption[] {
@@ -35,7 +35,7 @@ export function getOptionsByName<TOption extends Option, TName extends string>(
  * @returns 
  * Array of options from base game and specified expansions
  */
-export function getOptionsByExpansion<TOption extends ExpansionOption>(
+export function getOptionsByExpansion<TName extends string, TOption extends ExpansionOption<TName>>(
 	options: TOption[],
 	expansions: ExpansionName[]
 ): TOption[] {

--- a/src/functions/get-valid-combos.ts
+++ b/src/functions/get-valid-combos.ts
@@ -1,15 +1,15 @@
 import type { DifficultyOption } from "@models/game/difficulty";
 import type { Config } from "@models/config.interface";
-import type { AdversaryLevel } from "@models/game/adversaries";
-import type { Map } from "@models/game/maps";
-import type { Scenario } from "@models/game/scenarios";
+import type { AdversaryLevel, AdversaryLevelName } from "@models/game/adversaries";
+import type { Map, MapName } from "@models/game/maps";
+import type { Scenario, ScenarioName } from "@models/game/scenarios";
 import { ADVERSARIES } from "@data/adversaries";
 import { MAPS } from "@data/maps";
 import { SCENARIOS } from "@data/scenarios";
 import { getDifficulty } from "./get-difficulty";
 import { ComboAnalyzer } from "./utility/combo-analyzer";
 
-const comboAnalyzer = new ComboAnalyzer<DifficultyOption>();
+const comboAnalyzer = new ComboAnalyzer<DifficultyOption<MapName | AdversaryLevelName | ScenarioName>>();
 
 export function getValidCombos(config: Config): [Map, AdversaryLevel, Scenario][] {
 	const { mapNames, scenarioNames, adversaryNamesAndIds } = config;

--- a/src/models/game/adversaries.ts
+++ b/src/models/game/adversaries.ts
@@ -21,9 +21,8 @@ export type AdversaryLevelName =
 	"Level 5" |
 	"Level 6";
 
-export interface AdversaryLevel extends DifficultyOption {
+export interface AdversaryLevel extends DifficultyOption<AdversaryLevelName> {
 	id: AdversaryLevelId;
-	name: AdversaryLevelName;
 }
 
 export type AdversaryLevelId = "none" |
@@ -35,7 +34,6 @@ export type AdversaryLevelId = "none" |
 	"sc-0" | "sc-1" | "sc-2" | "sc-3" | "sc-4" | "sc-5" | "sc-6" |
 	"sw-0" | "sw-1" | "sw-2" | "sw-3" | "sw-4" | "sw-5" | "sw-6";
 
-export interface Adversary extends ExpansionOption {
-	name: AdversaryName,
+export interface Adversary extends ExpansionOption<AdversaryName> {
 	levels: AdversaryLevel[];
 }

--- a/src/models/game/board.ts
+++ b/src/models/game/board.ts
@@ -16,7 +16,6 @@ export type ThematicBoardName =
 	"Southeast" |
 	"Southwest";
 
-export interface Board extends ExpansionOption {
-	name: BalancedBoardName;
+export interface Board extends ExpansionOption<BalancedBoardName> {
 	thematicName: ThematicBoardName;
 }

--- a/src/models/game/difficulty.ts
+++ b/src/models/game/difficulty.ts
@@ -3,6 +3,6 @@ import type { Option } from "./option";
 
 export type Difficulty = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
-export interface DifficultyOption extends Option {
+export interface DifficultyOption<TName extends string> extends Option<TName> {
 	difficulty: Difficulty | ((expansions: ExpansionName[]) => Difficulty);
 }

--- a/src/models/game/expansions.ts
+++ b/src/models/game/expansions.ts
@@ -7,6 +7,6 @@ export type ExpansionName =
 	"Promo Pack 2"
 ;
 
-export interface ExpansionOption extends Option {
+export interface ExpansionOption<TName extends string> extends Option<TName> {
 	expansion?: ExpansionName;
 }

--- a/src/models/game/maps.ts
+++ b/src/models/game/maps.ts
@@ -3,6 +3,4 @@ import type { ExpansionOption } from "./expansions";
 
 export type MapName = "Balanced" | "Thematic";
 
-export interface Map extends DifficultyOption, ExpansionOption {
-	name: MapName;
-}
+export interface Map extends DifficultyOption<MapName>, ExpansionOption<MapName> {}

--- a/src/models/game/option.ts
+++ b/src/models/game/option.ts
@@ -1,3 +1,3 @@
-export interface Option {
-	name: string;
+export interface Option<TName extends string> {
+	name: TName;
 }

--- a/src/models/game/scenarios.ts
+++ b/src/models/game/scenarios.ts
@@ -17,6 +17,4 @@ export type ScenarioName =
 	"Varied Terrains" |
 	"Ward the Shores";
 
-export interface Scenario extends DifficultyOption, ExpansionOption {
-	name: ScenarioName;
-}
+export interface Scenario extends DifficultyOption<ScenarioName>, ExpansionOption<ScenarioName> {}

--- a/src/models/game/spirits.ts
+++ b/src/models/game/spirits.ts
@@ -26,6 +26,4 @@ export type SpiritName =
 	"Vital Strength of the Earth" |
 	"Volcano Looming High";
 
-export interface Spirit extends ExpansionOption {
-	name: SpiritName;
-}
+export interface Spirit extends ExpansionOption<SpiritName> {}


### PR DESCRIPTION
**Work done:**

1. Refactors `Option` to accept a generic argument for its `name` property
2. Updates all other types/functions that this change has a cascading effect on (most files, since `Option` is foundational)