### PR TITLE
[#25] Support new Spirits on Horizons of Spirit Island

### DIFF
--- a/src/data/expansions.ts
+++ b/src/data/expansions.ts
@@ -4,5 +4,6 @@ export const EXPANSIONS: ExpansionName[] = [
 	"Branch & Claw",
 	"Jagged Earth",
 	"Promo Pack 1",
-	"Promo Pack 2"
+	"Promo Pack 2",
+	"Horizons of Spirit Island"
 ];

--- a/src/data/spirits.ts
+++ b/src/data/spirits.ts
@@ -25,4 +25,9 @@ export const SPIRITS: Spirit[] = [
 	{ name: "Vengeance as a Burning Plague", expansion: "Jagged Earth" },
 	{ name: "Vital Strength of the Earth" },
 	{ name: "Volcano Looming High", expansion: "Jagged Earth" },
+	{ name: "Devouring Teeth Lurk Underfoot", expansion: "Horizons of Spirit Island" },
+	{ name: "Eyes Watch From the Trees", expansion: "Horizons of Spirit Island" },
+	{ name: "Fathomless Mud of the Swamp", expansion: "Horizons of Spirit Island" },
+	{ name: "Rising Heat of Stone and Sand", expansion: "Horizons of Spirit Island" },
+	{ name: "Sun-Bright Whirlwind", expansion: "Horizons of Spirit Island" }	
 ];

--- a/src/functions/create-game-setup.spec.ts
+++ b/src/functions/create-game-setup.spec.ts
@@ -29,7 +29,7 @@ describe("createGameSetup", () => {
 
 		expect(boards).toHaveLength(4);
 		expect(spirits).toHaveLength(4);
-		expect(expansions).toStrictEqual(["Branch & Claw", "Jagged Earth", "Promo Pack 1", "Promo Pack 2"]);
+		expect(expansions).toStrictEqual(["Branch & Claw", "Jagged Earth", "Promo Pack 1", "Promo Pack 2", "Horizons of Spirit Island"]);
 		expect(difficulty).toBeGreaterThanOrEqual(5);
 		expect(difficulty).toBeLessThanOrEqual(8);
 	});

--- a/src/functions/create-model.spec.ts
+++ b/src/functions/create-model.spec.ts
@@ -88,6 +88,24 @@ describe("createModel", () => {
 				"Vital Strength of the Earth",
 			]);
 		});
+
+		it("gets base game + Horizons of Spirit Island spirits", () => {
+			expect(createSpiritsModel(["Horizons of Spirit Island"])).toStrictEqual([
+				"A Spread of Rampant Green",
+				"Bringer of Dreams and Nightmares",
+				"Lightning's Swift Strike",
+				"Ocean's Hungry Grasp",
+				"River Surges in Sunlight",
+				"Shadows Flicker Like Flame",
+				"Thunderspeaker",
+				"Vital Strength of the Earth",
+				"Devouring Teeth Lurk Underfoot",
+				"Eyes Watch From the Trees",
+				"Fathomless Mud of the Swamp",
+				"Rising Heat of Stone and Sand",
+				"Sun-Bright Whirlwind"
+			]);
+		});
 	});
 
 	describe("createMapsModel", () => {

--- a/src/models/game/expansions.ts
+++ b/src/models/game/expansions.ts
@@ -4,7 +4,8 @@ export type ExpansionName =
 	"Branch & Claw" |
 	"Jagged Earth" |
 	"Promo Pack 1" |
-	"Promo Pack 2"
+	"Promo Pack 2" |
+	"Horizons of Spirit Island"
 ;
 
 export interface ExpansionOption<TName extends string> extends Option<TName> {

--- a/src/models/game/spirits.ts
+++ b/src/models/game/spirits.ts
@@ -24,6 +24,11 @@ export type SpiritName =
 	"Thunderspeaker" |
 	"Vengeance as a Burning Plague" |
 	"Vital Strength of the Earth" |
-	"Volcano Looming High";
+	"Volcano Looming High" |
+	"Devouring Teeth Lurk Underfoot" | 
+	"Eyes Watch From the Trees" |
+	"Fathomless Mud of the Swamp" | 
+	"Rising Heat of Stone and Sand" | 
+	"Sun-Bright Whirlwind";
 
 export interface Spirit extends ExpansionOption<SpiritName> {}


### PR DESCRIPTION
On this PR i tackle this issue : https://github.com/johnnycopes/spirit-islander/issues/25
On the latest Spirit Island expansion, Horizons of Spirit Island (More Info here https://spiritislandwiki.com/index.php?title=Horizons_of_Spirit_Island) there are 5 new low complexity spirits :
![image](https://user-images.githubusercontent.com/15672917/195290005-e1e13e02-a92a-476f-b9d4-a5d3416413ce.png)

Since the expansion is already out and people are playing with it, we should support it so that people can have these new spirits appear on the random selection :)